### PR TITLE
com.utilities.rest 2.2.7

### DIFF
--- a/Utilities.Rest/Packages/com.utilities.rest/Runtime/AbstractAuthentication.cs
+++ b/Utilities.Rest/Packages/com.utilities.rest/Runtime/AbstractAuthentication.cs
@@ -18,7 +18,7 @@ namespace Utilities.WebRequestRest.Interfaces
         /// <returns>
         /// The loaded <see cref="IAuthentication{T}"/> or <see langword="null"/>.
         /// </returns>
-        public abstract TAuthentication LoadFromAsset<T>() where T : ScriptableObject, IConfiguration;
+        public abstract TAuthentication LoadFromAsset<T>(T asset = null) where T : ScriptableObject, IConfiguration;
 
         /// <summary>
         /// Attempts to load the authentication from the system environment variables.

--- a/Utilities.Rest/Packages/com.utilities.rest/package.json
+++ b/Utilities.Rest/Packages/com.utilities.rest/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.Rest",
   "description": "This package contains useful RESTful utilities for the Unity Game Engine.",
   "keywords": [],
-  "version": "2.2.6",
+  "version": "2.2.7",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.rest#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.rest/releases",

--- a/Utilities.Rest/Packages/manifest.json
+++ b/Utilities.Rest/Packages/manifest.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "com.unity.ide.rider": "3.0.26",
     "com.unity.ide.visualstudio": "2.0.22",
-    "com.utilities.buildpipeline": "1.1.8"
+    "com.utilities.buildpipeline": "1.1.9"
   },
   "scopedRegistries": [
     {


### PR DESCRIPTION
- refactored AbstractAuthentication.LoadFromAsset<T> to take optional scriptable object asset to skip expensive Resources.LoadAll<T> in implementations