### PR TITLE
com.utilities.rest 2.3.1

### DIFF
--- a/Utilities.Rest/Packages/com.utilities.rest/package.json
+++ b/Utilities.Rest/Packages/com.utilities.rest/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.Rest",
   "description": "This package contains useful RESTful utilities for the Unity Game Engine.",
   "keywords": [],
-  "version": "2.3.0",
+  "version": "2.3.1",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.rest#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.rest/releases",


### PR DESCRIPTION
- no change, but new tag to fix cursed release version on OpenUPM