### PR TITLE
feature/ Clean up redundancies

### DIFF
--- a/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
+++ b/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
@@ -474,16 +474,6 @@ namespace Utilities.WebRequestRest
 
         #endregion Download Cache
 
-        [Obsolete("use new overload with debug support")]
-        public static async Task<Texture2D> DownloadTextureAsync(
-            string url,
-            string fileName = null,
-            RestParameters parameters = null,
-            CancellationToken cancellationToken = default)
-        {
-            return await DownloadTextureAsync(url, fileName, parameters, false, cancellationToken);
-        }
-
         /// <summary>
         /// Download a <see cref="Texture2D"/> from the provided <see cref="url"/>.
         /// </summary>
@@ -554,16 +544,6 @@ namespace Utilities.WebRequestRest
 
             texture.name = Path.GetFileNameWithoutExtension(cachePath);
             return texture;
-        }
-
-        [Obsolete("Use new overload with debug support")]
-        public static async Task<AudioClip> DownloadAudioClipAsync(
-            string url,
-            AudioType audioType,
-            RestParameters parameters = null,
-            CancellationToken cancellationToken = default)
-        {
-            return await DownloadAudioClipAsync(url, audioType, httpMethod: UnityWebRequest.kHttpVerbGET, parameters: parameters, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -911,16 +891,6 @@ namespace Utilities.WebRequestRest
         }
 
 #endif // UNITY_ADDRESSABLES
-
-        [Obsolete("use new overload with debug support")]
-        public static async Task<string> DownloadFileAsync(
-            string url,
-            string fileName = null,
-            RestParameters parameters = null,
-            CancellationToken cancellationToken = default)
-        {
-            return await DownloadFileAsync(url, fileName, parameters, false, cancellationToken);
-        }
 
         /// <summary>
         /// Download a file from the provided <see cref="url"/>.

--- a/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
+++ b/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
@@ -132,11 +132,7 @@ namespace Utilities.WebRequestRest
             RestParameters parameters = null,
             CancellationToken cancellationToken = default)
         {
-#if UNITY_2022_2_OR_NEWER
             using var webRequest = new UnityWebRequest(query, UnityWebRequest.kHttpVerbPOST);
-#else
-            using var webRequest = new UnityWebRequest(query, UnityWebRequest.kHttpVerbPOST);
-#endif
             return await webRequest.SendAsync(parameters, cancellationToken);
         }
 
@@ -172,11 +168,7 @@ namespace Utilities.WebRequestRest
             RestParameters parameters = null,
             CancellationToken cancellationToken = default)
         {
-#if UNITY_2022_2_OR_NEWER
             using var webRequest = new UnityWebRequest(query, UnityWebRequest.kHttpVerbPOST);
-#else
-            using var webRequest = new UnityWebRequest(query, UnityWebRequest.kHttpVerbPOST);
-#endif
             var data = new UTF8Encoding().GetBytes(jsonData);
             using var uploadHandler = new UploadHandlerRaw(data);
             webRequest.uploadHandler = uploadHandler;
@@ -202,11 +194,7 @@ namespace Utilities.WebRequestRest
             RestParameters parameters = null,
             CancellationToken cancellationToken = default)
         {
-#if UNITY_2022_2_OR_NEWER
             using var webRequest = new UnityWebRequest(query, UnityWebRequest.kHttpVerbPOST);
-#else
-            using var webRequest = new UnityWebRequest(query, UnityWebRequest.kHttpVerbPOST);
-#endif
             var data = new UTF8Encoding().GetBytes(jsonData);
             using var uploadHandler = new UploadHandlerRaw(data);
             webRequest.uploadHandler = uploadHandler;
@@ -234,11 +222,7 @@ namespace Utilities.WebRequestRest
             RestParameters parameters = null,
             CancellationToken cancellationToken = default)
         {
-#if UNITY_2022_2_OR_NEWER
             using var webRequest = new UnityWebRequest(query, UnityWebRequest.kHttpVerbPOST);
-#else
-            using var webRequest = new UnityWebRequest(query, UnityWebRequest.kHttpVerbPOST);
-#endif
             var data = new UTF8Encoding().GetBytes(jsonData);
             using var uploadHandler = new UploadHandlerRaw(data);
             webRequest.uploadHandler = uploadHandler;
@@ -273,11 +257,7 @@ namespace Utilities.WebRequestRest
             RestParameters parameters = null,
             CancellationToken cancellationToken = default)
         {
-#if UNITY_2022_2_OR_NEWER
             using var webRequest = new UnityWebRequest(query, UnityWebRequest.kHttpVerbPOST);
-#else
-            using var webRequest = new UnityWebRequest(query, UnityWebRequest.kHttpVerbPOST);
-#endif
             using var uploadHandler = new UploadHandlerRaw(bodyData);
             webRequest.uploadHandler = uploadHandler;
             using var downloadHandler = new DownloadHandlerBuffer();
@@ -300,11 +280,7 @@ namespace Utilities.WebRequestRest
             RestParameters parameters = null,
             CancellationToken cancellationToken = default)
         {
-#if UNITY_2022_2_OR_NEWER
             using var webRequest = new UnityWebRequest(query, UnityWebRequest.kHttpVerbPOST);
-#else
-            using var webRequest = new UnityWebRequest(query, UnityWebRequest.kHttpVerbPOST);
-#endif
             var boundary = UnityWebRequest.GenerateBoundary();
             var formSections = UnityWebRequest.SerializeFormSections(form, boundary);
             using var uploadHandler = new UploadHandlerRaw(formSections);


### PR DESCRIPTION
# Description

Clean up redundant code in the Rest Library:

* Unnecessary #if UNITY statements (identical code)
* Remove Obsolete functions (actually caused duplicate signature issues)

