### PR TITLE
Feature/ Add byte[] download methods

### DIFF
--- a/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
+++ b/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
@@ -928,21 +928,12 @@ namespace Utilities.WebRequestRest
         {
             await Awaiters.UnityMainThread;
             byte[] bytes = null;
-
             var filePath = await DownloadFileAsync(url, fileName, parameters, cancellationToken);
-            var absolutefilePath = filePath.Replace("file://", string.Empty);
+            var localPath = filePath.Replace("file://", string.Empty);
 
-            if (File.Exists(absolutefilePath))
+            if (File.Exists(localPath))
             {
-                try
-                {
-                    bytes = await File.ReadAllBytesAsync(absolutefilePath, cancellationToken);
-                }
-                catch (Exception ex)
-                {
-                    Debug.LogError(ex);
-                    throw;
-                }
+                bytes = await File.ReadAllBytesAsync(localPath, cancellationToken).ConfigureAwait(true);
             }
 
             return bytes;
@@ -955,14 +946,13 @@ namespace Utilities.WebRequestRest
         /// <param name="parameters">Optional, <see cref="RestParameters"/>.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns>The bytes downloaded from the server.</returns>
-        /// <remarks>This call cannot be cached, if you want the cached version of the file, then use the <see cref="DownloadFileBytesAsync"/> function.</remarks>
+        /// <remarks>This request does not cache results.</remarks>
         public static async Task<byte[]> DownloadBytesAsync(
             string url,
             RestParameters parameters = null,
             CancellationToken cancellationToken = default)
         {
             await Awaiters.UnityMainThread;
-
             using var webRequest = UnityWebRequest.Get(url);
             using var downloadHandlerBuffer = new DownloadHandlerBuffer();
             webRequest.downloadHandler = downloadHandlerBuffer;

--- a/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
+++ b/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
@@ -1003,7 +1003,7 @@ namespace Utilities.WebRequestRest
             byte[] bytes = null;
 
             var filePath = await DownloadFileAsync(url, fileName, parameters, false, cancellationToken);
-            var absolutefilePath = filePath.Replace("file://", "");
+            var absolutefilePath = filePath.Replace("file://", string.Empty);
             if (File.Exists(absolutefilePath))
             {
                 try

--- a/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
+++ b/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
@@ -983,6 +983,15 @@ namespace Utilities.WebRequestRest
             return filePath;
         }
 
+        /// <summary>
+        /// Download a file from the provided <see cref="url"/> and return the <see cref="byte[]"/> array of its contents.
+        /// </summary>
+        /// <param name="url">The url to download the file from.</param>
+        /// <param name="fileName">Optional, file name to download (including extension).</param>
+        /// <param name="parameters">Optional, <see cref="RestParameters"/>.</param>
+        /// <param name="debug">Optional, debug http request.</param>
+        /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+        /// <returns>The <see cref="byte[]"/> of the downloaded file.</returns>
         public static async Task<byte[]> DownloadFileBytesAsync(
         string url,
         string fileName = null,
@@ -1010,8 +1019,6 @@ namespace Utilities.WebRequestRest
 
             return bytes;
         }
-
-
         #endregion Get Multimedia Content
 
         /// <summary>

--- a/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
+++ b/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
@@ -1019,6 +1019,31 @@ namespace Utilities.WebRequestRest
 
             return bytes;
         }
+
+        /// <summary>
+        /// Download a <see cref="byte[]"/> from the provided <see cref="url"/>.
+        /// </summary>
+        /// <param name="url">The url to download from.</param>
+        /// <param name="parameters">Optional, <see cref="RestParameters"/>.</param>
+        /// <param name="debug">Optional, debug http request.</param>
+        /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+        /// <returns>The <see cref="byte[]"/> downloaded from the server.</returns>
+        /// <remarks>This call cannot be cached, if you want the cached version of a <see cref="byte[]"/>, then use the <see cref="DownloadFileBytesAsync"/> function.</remarks>
+        public static async Task<byte[]> DownloadBytesAsync(
+        string url,
+        RestParameters parameters = null,
+        bool debug = false,
+        CancellationToken cancellationToken = default)
+        {
+            await Awaiters.UnityMainThread;
+
+            using var webRequest = UnityWebRequest.Get(url);
+            using var downloadHandlerBuffer = new DownloadHandlerBuffer();
+            webRequest.downloadHandler = downloadHandlerBuffer;
+            var response = await webRequest.SendAsync(parameters, cancellationToken);
+            response.Validate(debug);
+            return response.Data;
+        }
         #endregion Get Multimedia Content
 
         /// <summary>

--- a/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
+++ b/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
@@ -913,32 +913,30 @@ namespace Utilities.WebRequestRest
         }
 
         /// <summary>
-        /// Download a file from the provided <see cref="url"/> and return the <see cref="byte[]"/> array of its contents.
+        /// Download a file from the provided <see cref="url"/> and return the contents as bytes.
         /// </summary>
         /// <param name="url">The url to download the file from.</param>
         /// <param name="fileName">Optional, file name to download (including extension).</param>
         /// <param name="parameters">Optional, <see cref="RestParameters"/>.</param>
-        /// <param name="debug">Optional, debug http request.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
-        /// <returns>The <see cref="byte[]"/> of the downloaded file.</returns>
+        /// <returns>The bytes of the downloaded file.</returns>
         public static async Task<byte[]> DownloadFileBytesAsync(
-        string url,
-        string fileName = null,
-        RestParameters parameters = null,
-        bool debug = false,
-        CancellationToken cancellationToken = default)
+            string url,
+            string fileName = null,
+            RestParameters parameters = null,
+            CancellationToken cancellationToken = default)
         {
             await Awaiters.UnityMainThread;
             byte[] bytes = null;
 
-            var filePath = await DownloadFileAsync(url, fileName, parameters, false, cancellationToken);
+            var filePath = await DownloadFileAsync(url, fileName, parameters, cancellationToken);
             var absolutefilePath = filePath.Replace("file://", string.Empty);
 
             if (File.Exists(absolutefilePath))
             {
                 try
                 {
-                    bytes = File.ReadAllBytes(absolutefilePath);
+                    bytes = await File.ReadAllBytesAsync(absolutefilePath, cancellationToken);
                 }
                 catch (Exception ex)
                 {
@@ -951,19 +949,17 @@ namespace Utilities.WebRequestRest
         }
 
         /// <summary>
-        /// Download a <see cref="byte[]"/> from the provided <see cref="url"/>.
+        /// Download raw file contents from the provided <see cref="url"/>.
         /// </summary>
         /// <param name="url">The url to download from.</param>
         /// <param name="parameters">Optional, <see cref="RestParameters"/>.</param>
-        /// <param name="debug">Optional, debug http request.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
-        /// <returns>The <see cref="byte[]"/> downloaded from the server.</returns>
-        /// <remarks>This call cannot be cached, if you want the cached version of a <see cref="byte[]"/>, then use the <see cref="DownloadFileBytesAsync"/> function.</remarks>
+        /// <returns>The bytes downloaded from the server.</returns>
+        /// <remarks>This call cannot be cached, if you want the cached version of the file, then use the <see cref="DownloadFileBytesAsync"/> function.</remarks>
         public static async Task<byte[]> DownloadBytesAsync(
-        string url,
-        RestParameters parameters = null,
-        bool debug = false,
-        CancellationToken cancellationToken = default)
+            string url,
+            RestParameters parameters = null,
+            CancellationToken cancellationToken = default)
         {
             await Awaiters.UnityMainThread;
 
@@ -971,9 +967,10 @@ namespace Utilities.WebRequestRest
             using var downloadHandlerBuffer = new DownloadHandlerBuffer();
             webRequest.downloadHandler = downloadHandlerBuffer;
             var response = await webRequest.SendAsync(parameters, cancellationToken);
-            response.Validate(debug);
+            response.Validate(parameters?.Debug ?? false);
             return response.Data;
         }
+
         #endregion Get Multimedia Content
 
         /// <summary>

--- a/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
+++ b/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
@@ -983,6 +983,35 @@ namespace Utilities.WebRequestRest
             return filePath;
         }
 
+        public static async Task<byte[]> DownloadFileBytesAsync(
+        string url,
+        string fileName = null,
+        RestParameters parameters = null,
+        bool debug = false,
+        CancellationToken cancellationToken = default)
+        {
+            await Awaiters.UnityMainThread;
+            byte[] bytes = null;
+
+            var filePath = await DownloadFileAsync(url, fileName, parameters, false, cancellationToken);
+            var absolutefilePath = filePath.Replace("file://", "");
+            if (File.Exists(absolutefilePath))
+            {
+                try
+                {
+                    bytes = File.ReadAllBytes(absolutefilePath);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError(ex);
+                    throw;
+                }
+            }
+
+            return bytes;
+        }
+
+
         #endregion Get Multimedia Content
 
         /// <summary>

--- a/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
+++ b/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
@@ -1004,6 +1004,7 @@ namespace Utilities.WebRequestRest
 
             var filePath = await DownloadFileAsync(url, fileName, parameters, false, cancellationToken);
             var absolutefilePath = filePath.Replace("file://", string.Empty);
+
             if (File.Exists(absolutefilePath))
             {
                 try


### PR DESCRIPTION
# Description

Add two methods for handling byte[] downloading:

* Added `DownloadFileBytesAsync` method - Downloads a file (with caching) and returns the byte[] of the file.
* Added `DownloadBytesAsync` method - Only downloads and returns the byte[] from a url, no caching.