### PR TITLE
com.utilities.rest 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,21 @@ response.Validate(debug: true);
 
 #### Server Sent Events
 
+> [!WARNING]
+> Breaking change. `eventData` payloads are now json objects where the type is the key and field data is value.
+> For existing data callbacks, they are now nested: `{"data":"{<payload data>}"}`
+
+Handles [server sent event](https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events) messages.
+
+`eventData` json Schema:
+
+```json
+{
+  "type":"value",
+  "data":"{<payload data>}" // nullable
+}
+```
+
 ```csharp
 var jsonData = "{\"data\":\"content\"}";
 var response = await Rest.PostAsync("www.your.api/endpoint", jsonData, eventData => {

--- a/Utilities.Rest/Packages/com.utilities.rest/Documentation~/README.md
+++ b/Utilities.Rest/Packages/com.utilities.rest/Documentation~/README.md
@@ -115,6 +115,21 @@ response.Validate(debug: true);
 
 #### Server Sent Events
 
+> [!WARNING]
+> Breaking change. `eventData` payloads are now json objects where the type is the key and field data is value.
+> For existing data callbacks, they are now nested: `{"data":"{<payload data>}"}`
+
+Handles [server sent event](https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events) messages.
+
+`eventData` json Schema:
+
+```json
+{
+  "type":"value",
+  "data":"{<payload data>}" // nullable
+}
+```
+
 ```csharp
 var jsonData = "{\"data\":\"content\"}";
 var response = await Rest.PostAsync("www.your.api/endpoint", jsonData, eventData => {

--- a/Utilities.Rest/Packages/com.utilities.rest/Runtime/DownloadHandlerCallback.cs
+++ b/Utilities.Rest/Packages/com.utilities.rest/Runtime/DownloadHandlerCallback.cs
@@ -48,7 +48,7 @@ namespace Utilities.WebRequestRest
                     var buffer = new byte[bytesToRead];
                     var bytesRead = stream.Read(buffer, 0, (int)bytesToRead);
                     streamPosition += bytesRead;
-                    OnDataReceived?.Invoke(new Response(webRequest.url, webRequest.method, null, true, null, buffer, webRequest.responseCode, webRequest.GetResponseHeaders()));
+                    OnDataReceived?.Invoke(new Response(webRequest.url, webRequest.method, null, true, null, buffer, webRequest.responseCode, webRequest.GetResponseHeaders(), null, null));
                 }
             }
             catch (Exception e)
@@ -69,7 +69,7 @@ namespace Utilities.WebRequestRest
                     var buffer = new byte[StreamOffset];
                     var bytesRead = stream.Read(buffer);
                     streamPosition += bytesRead;
-                    OnDataReceived?.Invoke(new Response(webRequest.url, webRequest.method, null, true, null, buffer, webRequest.responseCode, webRequest.GetResponseHeaders()));
+                    OnDataReceived?.Invoke(new Response(webRequest.url, webRequest.method, null, true, null, buffer, webRequest.responseCode, webRequest.GetResponseHeaders(), null, null));
                 }
             }
             catch (Exception e)

--- a/Utilities.Rest/Packages/com.utilities.rest/Runtime/RestParameters.cs
+++ b/Utilities.Rest/Packages/com.utilities.rest/Runtime/RestParameters.cs
@@ -85,6 +85,8 @@ namespace Utilities.WebRequestRest
 
         internal int ServerSentEventCount { get; set; }
 
+        internal readonly List<Tuple<string, string, string>> ServerSentEvents = new();
+
         /// <summary>
         /// Cache downloaded content.<br/>
         /// Default is true.

--- a/Utilities.Rest/Packages/com.utilities.rest/package.json
+++ b/Utilities.Rest/Packages/com.utilities.rest/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.Rest",
   "description": "This package contains useful RESTful utilities for the Unity Game Engine.",
   "keywords": [],
-  "version": "2.5.7",
+  "version": "3.0.0",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.rest#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.rest/releases",
@@ -15,7 +15,7 @@
   "author": "Stephen Hodgson",
   "url": "https://github.com/StephenHodgson",
   "dependencies": {
-    "com.utilities.async": "2.1.5",
+    "com.utilities.async": "2.1.6",
     "com.utilities.extensions": "1.1.15",
     "com.unity.modules.unitywebrequest": "1.0.0",
     "com.unity.modules.unitywebrequestassetbundle": "1.0.0",

--- a/Utilities.Rest/Packages/manifest.json
+++ b/Utilities.Rest/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "com.unity.addressables": "1.21.20",
+    "com.unity.addressables": "1.21.21",
     "com.unity.ide.rider": "3.0.28",
     "com.unity.ide.visualstudio": "2.0.22",
     "com.utilities.buildpipeline": "1.3.4"


### PR DESCRIPTION
- overhauled Server Sent Event callbacks
  - properly handles all event types and fields
  - breaking change: data payloads now come nested in json object
- Rest.Response.ctr has new overload which takes RestParameters
- updated com.utilities.async -> 2.1.6