### PR TITLE
com.utilities.rest 3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Advanced features includes progress notifications, authentication and native mul
 - [Rest Parameters](#rest-parameters)
 - [Get](#get)
 - [Post](#post)
-  - [Server Sent Events](#server-sent-events) :new:
+  - [Server Sent Events](#server-sent-events) :warning:
   - [Data Received Callbacks](#data-received-callbacks)
 - [Put](#put)
 - [Patch](#patch)
@@ -115,10 +115,14 @@ response.Validate(debug: true);
 
 #### Server Sent Events
 
+> [!WARNING]
+> This callback was recently refactored from `Action<Response, ServerSentEvent>` to `Func<Response, ServerSentEvent, Task>`. To update this callback without asynchronous calls, just add `await Task.CompletedTask;` at the end of your callback function.
+
 ```csharp
 var jsonData = "{\"data\":\"content\"}";
-var response = await Rest.PostAsync("www.your.api/endpoint", jsonData, (sseResponse, ssEvent) => {
+var response = await Rest.PostAsync("www.your.api/endpoint", jsonData, async (sseResponse, ssEvent) => {
     Debug.Log(ssEvent);
+    await Task.CompletedTask;
 });
 // Validates the response for you and will throw a RestException if the response is unsuccessful.
 response.Validate(debug: true);

--- a/Utilities.Rest/Packages/com.utilities.rest/Documentation~/README.md
+++ b/Utilities.Rest/Packages/com.utilities.rest/Documentation~/README.md
@@ -46,7 +46,7 @@ Advanced features includes progress notifications, authentication and native mul
 - [Rest Parameters](#rest-parameters)
 - [Get](#get)
 - [Post](#post)
-  - [Server Sent Events](#server-sent-events) :new:
+  - [Server Sent Events](#server-sent-events) :warning:
   - [Data Received Callbacks](#data-received-callbacks)
 - [Put](#put)
 - [Patch](#patch)
@@ -115,10 +115,14 @@ response.Validate(debug: true);
 
 #### Server Sent Events
 
+> [!WARNING]
+> This callback was recently refactored from `Action<Response, ServerSentEvent>` to `Func<Response, ServerSentEvent, Task>`. To update this callback without asynchronous calls, just add `await Task.CompletedTask;` at the end of your callback function.
+
 ```csharp
 var jsonData = "{\"data\":\"content\"}";
-var response = await Rest.PostAsync("www.your.api/endpoint", jsonData, (sseResponse, ssEvent) => {
+var response = await Rest.PostAsync("www.your.api/endpoint", jsonData, async (sseResponse, ssEvent) => {
     Debug.Log(ssEvent);
+    await Task.CompletedTask;
 });
 // Validates the response for you and will throw a RestException if the response is unsuccessful.
 response.Validate(debug: true);

--- a/Utilities.Rest/Packages/com.utilities.rest/package.json
+++ b/Utilities.Rest/Packages/com.utilities.rest/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.Rest",
   "description": "This package contains useful RESTful utilities for the Unity Game Engine.",
   "keywords": [],
-  "version": "3.1.2",
+  "version": "3.2.0",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.rest#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.rest/releases",


### PR DESCRIPTION
- Refactor `serverSentEventHandler` from `Action<Response, ServerSentEvent>` to `Func<Response, ServerSentEvent, Task>`
- Fix `Validate(debug)` not capturing request body for json payloads