### PR TITLE
com.utilities.rest 3.3.3

### DIFF
--- a/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
+++ b/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
@@ -1374,7 +1374,14 @@ namespace Utilities.WebRequestRest
                 {
                     await new WaitUntil(() => serverSentEventQueue.Count == 0);
                     serverSentEventCts?.Cancel();
-                    serverSentEventCts?.Dispose();
+                    
+                    // We do not dispose the serverSentEventCts here because doing so can trigger
+                    // a race condition if any SSE handler is still in flight and attempts to read
+                    // serverSentEventCts.Token. By skipping Dispose(), we avoid intermittent
+                    // ObjectDisposedExceptions on slower devices or in concurrent scenarios. The
+                    // GC will eventually reclaim the CTS resources, which is typically acceptable
+                    // given the low overhead of a single CancellationTokenSource.
+                    //serverSentEventCts?.Dispose();
                 }
             }
 

--- a/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
+++ b/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
@@ -1374,14 +1374,6 @@ namespace Utilities.WebRequestRest
                 {
                     await new WaitUntil(() => serverSentEventQueue.Count == 0);
                     serverSentEventCts?.Cancel();
-                    
-                    // We do not dispose the serverSentEventCts here because doing so can trigger
-                    // a race condition if any SSE handler is still in flight and attempts to read
-                    // serverSentEventCts.Token. By skipping Dispose(), we avoid intermittent
-                    // ObjectDisposedExceptions on slower devices or in concurrent scenarios. The
-                    // GC will eventually reclaim the CTS resources, which is typically acceptable
-                    // given the low overhead of a single CancellationTokenSource.
-                    //serverSentEventCts?.Dispose();
                 }
             }
 

--- a/Utilities.Rest/Packages/com.utilities.rest/package.json
+++ b/Utilities.Rest/Packages/com.utilities.rest/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.Rest",
   "description": "This package contains useful RESTful utilities for the Unity Game Engine.",
   "keywords": [],
-  "version": "3.3.2",
+  "version": "3.3.3",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.rest#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.rest/releases",


### PR DESCRIPTION
**Proposed Fix**  
This PR removes the explicit disposal of the `CancellationTokenSource` used for SSE (Server-Sent Events) in streaming scenarios. We’ve been testing with the **OpenAI** package, where partial chunk responses are delivered over SSE, and encountered intermittent `ObjectDisposedException` crashes on Android (specifically tested on the **HTC Vive Focus 3**). By relying on garbage collection instead of immediate disposal, we eliminate this race condition for streaming requests.

**Use Case & Context**  
- **Platform**: Android (HTC Vive Focus 3).  
- **Library**: Streaming partial responses from OpenAI with SSE.  
- **Issue**: Occasional `ObjectDisposedException` mid-stream, preventing stable partial message handling.  
- **Reason**: The SSE handler continued reading `cts.Token` after the library invoked `Dispose()`.

**Solution**  
- Continue calling `cts.Cancel()` so any ongoing operations can exit, but **omit** `cts.Dispose()`.  
- The GC will eventually collect the CTS object, which prevents the race condition on slower or more concurrency-prone devices.

**Rationale**  
- The memory overhead of not disposing a single CTS object is minimal.  
- This significantly improves stability for streaming partial responses on Android devices without extra concurrency complexities.

**Impact**  
- Streaming flows remain robust on devices like the Vive Focus 3 and other Android hardware.  
- Slight change in memory/resource management: the CTS is left to GC, rather than explicitly disposed.

**Testing**  
- Verified no more `ObjectDisposedException` logs in typical SSE streaming scenarios with the OpenAI package.  
- Full streaming partial responses on HTC Vive Focus 3 under moderate concurrency loads.

Please let me know if you have any questions or prefer a different approach for concurrency disposal.
