### PR TITLE
com.utilities.rest 3.3.9

### DIFF
--- a/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
+++ b/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
@@ -494,14 +494,7 @@ namespace Utilities.WebRequestRest
 
         private const string download_cache = nameof(download_cache);
 
-        /* We start with a thread-safe *stub* cache so that background threads can safely call Rest even before Unity’s main thread runs Init_Rest().
-         * This No-op cache never touches Unity APIs and stores nothing on disk.
-         * Until Init_Rest() swaps in DiskDownloadCache, helpers that rely on the
-         * cache (e.g. DownloadTextureAsync / DownloadAudioClipAsync / DownloadFileAsync) will simply redownload the asset each time.
-         */
-        private static IDownloadCache cache = new NoOpDownloadCache();
-        // Returns the already-initialized cache. Call Init_Rest() once on the main thread before using Rest from worker threads.
-        private static IDownloadCache Cache => cache;
+        private static IDownloadCache Cache { get; set; }
 
 #if UNITY_EDITOR
         [UnityEditor.InitializeOnLoadMethod]
@@ -510,11 +503,9 @@ namespace Utilities.WebRequestRest
 #endif
         private static void Init_Rest()
         {
-            // Unity API -> main thread only.
             downloadLocation = Application.temporaryCachePath;
-            
-            // Now that we are on the main thread it is safe to decide which cache implementation to use.
-            cache = Application.platform == RuntimePlatform.WebGLPlayer
+
+            Cache = Application.platform == RuntimePlatform.WebGLPlayer
                     ? new NoOpDownloadCache()
                     : new DiskDownloadCache();
         }

--- a/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
+++ b/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
@@ -494,7 +494,7 @@ namespace Utilities.WebRequestRest
 
         private const string download_cache = nameof(download_cache);
 
-        private static IDownloadCache Cache { get; set; }
+        private static IDownloadCache cache;
 
 #if UNITY_EDITOR
         [UnityEditor.InitializeOnLoadMethod]
@@ -505,7 +505,7 @@ namespace Utilities.WebRequestRest
         {
             downloadLocation = Application.temporaryCachePath;
 
-            Cache = Application.platform == RuntimePlatform.WebGLPlayer
+            cache = Application.platform == RuntimePlatform.WebGLPlayer
                     ? new NoOpDownloadCache()
                     : new DiskDownloadCache();
         }
@@ -562,13 +562,13 @@ namespace Utilities.WebRequestRest
         /// Creates the <see cref="DownloadCacheDirectory"/> if it doesn't exist.
         /// </summary>
         public static void ValidateCacheDirectory()
-            => Cache.ValidateCacheDirectory();
+            => cache.ValidateCacheDirectory();
 
         /// <summary>
         /// Creates the <see cref="DownloadCacheDirectory"/> if it doesn't exist.
         /// </summary>
         public static Task ValidateCacheDirectoryAsync()
-            => Cache.ValidateCacheDirectoryAsync();
+            => cache.ValidateCacheDirectoryAsync();
 
         /// <summary>
         /// Try to get a file out of the download cache by uri reference.
@@ -577,7 +577,7 @@ namespace Utilities.WebRequestRest
         /// <param name="filePath">The file path to the cached item.</param>
         /// <returns>True, if the item was in cache, otherwise false.</returns>
         public static bool TryGetDownloadCacheItem(string uri, out string filePath)
-            => Cache.TryGetDownloadCacheItem(uri, out filePath);
+            => cache.TryGetDownloadCacheItem(uri, out filePath);
 
         /// <summary>
         /// Try to delete the cached item at the uri.
@@ -585,13 +585,13 @@ namespace Utilities.WebRequestRest
         /// <param name="uri">The uri key of the item.</param>
         /// <returns>True, if the cached item was successfully deleted.</returns>
         public static bool TryDeleteCacheItem(string uri)
-            => Cache.TryDeleteCacheItem(uri);
+            => cache.TryDeleteCacheItem(uri);
 
         /// <summary>
         /// Deletes all the files in the download cache.
         /// </summary>
         public static void DeleteDownloadCache()
-            => Cache.DeleteDownloadCache();
+            => cache.DeleteDownloadCache();
 
         /// <summary>
         /// We will try go guess the name based on the url.
@@ -661,7 +661,7 @@ namespace Utilities.WebRequestRest
 
                 if (!isCached && parameters.CacheDownloads)
                 {
-                    await Cache.WriteCacheItemAsync(webRequest.downloadHandler.data, cachePath, cancellationToken).ConfigureAwait(true);
+                    await cache.WriteCacheItemAsync(webRequest.downloadHandler.data, cachePath, cancellationToken).ConfigureAwait(true);
                 }
 
                 texture = ((DownloadHandlerTexture)webRequest.downloadHandler).texture;
@@ -779,7 +779,7 @@ namespace Utilities.WebRequestRest
 
                 if (!isCached && parameters.CacheDownloads)
                 {
-                    await Cache.WriteCacheItemAsync(downloadHandler.data, cachePath, cancellationToken);
+                    await cache.WriteCacheItemAsync(downloadHandler.data, cachePath, cancellationToken);
                 }
 
                 await Awaiters.UnityMainThread;

--- a/Utilities.Rest/Packages/com.utilities.rest/package.json
+++ b/Utilities.Rest/Packages/com.utilities.rest/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.Rest",
   "description": "This package contains useful RESTful utilities for the Unity Game Engine.",
   "keywords": [],
-  "version": "3.3.8",
+  "version": "3.3.9",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.rest#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.rest/releases",


### PR DESCRIPTION
- Fixes ensure all Unity API calls are done on main thread in `Init_Rest`
  - Ensure `Application.platform` is properly accessed before setting up `IDownloadCache` instance