### PR TITLE
com.utilities.rest 5.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ obj/
 *.suo
 /*.sln
 *.sln
+/*.slnx
+*.slnx
 *.user
 *.unityproj
 *.ipch

--- a/Utilities.Rest/Packages/com.utilities.rest/Runtime/DiskDownloadCache.cs
+++ b/Utilities.Rest/Packages/com.utilities.rest/Runtime/DiskDownloadCache.cs
@@ -27,7 +27,15 @@ namespace Utilities.WebRequestRest
         }
 
         public bool TryGetDownloadCacheItem(string fileName, out Uri fileUri)
-            => TryGetDownloadCacheItem(Rest.GetCacheItemUri(fileName), out fileUri);
+        {
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                fileUri = null;
+                return false;
+            }
+
+            return TryGetDownloadCacheItem(Rest.GetCacheItemUri(fileName), out fileUri);
+        }
 
         public bool TryGetDownloadCacheItem(Uri uri, out Uri fileUri)
         {

--- a/Utilities.Rest/Packages/com.utilities.rest/Runtime/DiskDownloadCache.cs
+++ b/Utilities.Rest/Packages/com.utilities.rest/Runtime/DiskDownloadCache.cs
@@ -27,7 +27,7 @@ namespace Utilities.WebRequestRest
         }
 
         public bool TryGetDownloadCacheItem(string fileName, out Uri fileUri)
-            => TryGetDownloadCacheItem(new Uri(Path.Combine(Rest.DownloadCacheDirectory, fileName)), out fileUri);
+            => TryGetDownloadCacheItem(Rest.GetCacheItemUri(fileName), out fileUri);
 
         public bool TryGetDownloadCacheItem(Uri uri, out Uri fileUri)
         {

--- a/Utilities.Rest/Packages/com.utilities.rest/Runtime/DiskDownloadCache.cs
+++ b/Utilities.Rest/Packages/com.utilities.rest/Runtime/DiskDownloadCache.cs
@@ -26,31 +26,34 @@ namespace Utilities.WebRequestRest
             ValidateCacheDirectory();
         }
 
-        public bool TryGetDownloadCacheItem(Uri uri, out Uri filePath)
+        public bool TryGetDownloadCacheItem(string fileName, out Uri fileUri)
+            => TryGetDownloadCacheItem(new Uri(Path.Combine(Rest.DownloadCacheDirectory, fileName)), out fileUri);
+
+        public bool TryGetDownloadCacheItem(Uri uri, out Uri fileUri)
         {
             ValidateCacheDirectory();
             bool exists;
 
-            if (uri.IsFile)
+            if (uri.Scheme == Uri.UriSchemeFile)
             {
-                filePath = uri;
+                fileUri = uri;
                 return File.Exists(uri.LocalPath);
             }
 
             if (Rest.TryGetFileNameFromUri(uri, out var fileName))
             {
-                filePath = new Uri(Path.Combine(Rest.DownloadCacheDirectory, fileName));
-                exists = File.Exists(filePath.LocalPath);
+                fileUri = new Uri(Path.Combine(Rest.DownloadCacheDirectory, fileName));
+                exists = File.Exists(fileUri.LocalPath);
             }
             else
             {
-                filePath = new Uri(Path.Combine(Rest.DownloadCacheDirectory, uri.GenerateGuidString()));
-                exists = File.Exists(filePath.LocalPath);
+                fileUri = new Uri(Path.Combine(Rest.DownloadCacheDirectory, uri.GenerateGuidString()));
+                exists = File.Exists(fileUri.LocalPath);
             }
 
             if (exists)
             {
-                filePath = new Uri(Path.GetFullPath(filePath.LocalPath));
+                fileUri = new Uri(Path.GetFullPath(fileUri.LocalPath));
             }
 
             return exists;

--- a/Utilities.Rest/Packages/com.utilities.rest/Runtime/Interfaces/IDownloadCache.cs
+++ b/Utilities.Rest/Packages/com.utilities.rest/Runtime/Interfaces/IDownloadCache.cs
@@ -12,6 +12,8 @@ namespace Utilities.WebRequestRest.Interfaces
 
         Task ValidateCacheDirectoryAsync();
 
+        bool TryGetDownloadCacheItem(string fileName, out Uri filePath);
+
         bool TryGetDownloadCacheItem(Uri uri, out Uri filePath);
 
         bool TryDeleteCacheItem(Uri uri);

--- a/Utilities.Rest/Packages/com.utilities.rest/Runtime/NoOpDownloadCache.cs
+++ b/Utilities.Rest/Packages/com.utilities.rest/Runtime/NoOpDownloadCache.cs
@@ -13,6 +13,12 @@ namespace Utilities.Rest
 
         public Task ValidateCacheDirectoryAsync() => Task.CompletedTask;
 
+        public bool TryGetDownloadCacheItem(string fileName, out Uri filePath)
+        {
+            filePath = null;
+            return false;
+        }
+
         public bool TryGetDownloadCacheItem(Uri uri, out Uri filePath)
         {
             filePath = null;

--- a/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
+++ b/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
@@ -749,26 +749,37 @@ namespace Utilities.WebRequestRest
             => cache.ValidateCacheDirectoryAsync();
 
         /// <summary>
-        /// Try to get a file out of the download cache by uri reference.
+        /// Try to get a file out of the download cache by fileName reference.
         /// </summary>
-        /// <param name="uri">The uri key of the item.</param>
+        /// <param name="fileName">The filename of the item.</param>
         /// <param name="filePath">The file path to the cached item.</param>
         /// <returns>True, if the item was in cache, otherwise false.</returns>
-        public static bool TryGetDownloadCacheItem(string uri, out string filePath)
+        public static bool TryGetDownloadCacheItem(string fileName, out string filePath)
         {
-            var result = TryGetDownloadCacheItem(new Uri(uri), out var local);
-            filePath = local.LocalPath;
+            var result = cache.TryGetDownloadCacheItem(fileName, out var fileUri);
+            filePath = fileUri?.LocalPath;
             return result;
+        }
+
+        /// <summary>
+        /// Try to get a file out of the download cache by fileName reference.
+        /// </summary>
+        /// <param name="fileName">The filename of the item.</param>
+        /// <param name="fileUri">The <see cref="Uri"/> to the cached item.</param>
+        /// <returns>True, if the item was in cache, otherwise false.</returns>
+        public static bool TryGetDownloadCacheItem(string fileName, out Uri fileUri)
+        {
+            return cache.TryGetDownloadCacheItem(fileName, out fileUri);
         }
 
         /// <summary>
         /// Try to get a file out of the download cache by uri reference.
         /// </summary>
         /// <param name="uri">The uri key of the item.</param>
-        /// <param name="filePath">The file path to the cached item.</param>
+        /// <param name="fileUri">The <see cref="Uri"/> to the cached item.</param>
         /// <returns>True, if the item was in cache, otherwise false.</returns>
-        public static bool TryGetDownloadCacheItem(Uri uri, out Uri filePath)
-            => cache.TryGetDownloadCacheItem(uri, out filePath);
+        public static bool TryGetDownloadCacheItem(Uri uri, out Uri fileUri)
+            => cache.TryGetDownloadCacheItem(uri, out fileUri);
 
         /// <summary>
         /// Try to delete the cached item at the uri.
@@ -776,7 +787,9 @@ namespace Utilities.WebRequestRest
         /// <param name="uri">The uri key of the item.</param>
         /// <returns>True, if the cached item was successfully deleted.</returns>
         public static bool TryDeleteCacheItem(string uri)
-            => TryDeleteCacheItem(new Uri(uri));
+        {
+            return TryDeleteCacheItem(new Uri(uri));
+        }
 
         /// <summary>
         /// Try to delete the cached item at the uri.
@@ -826,7 +839,7 @@ namespace Utilities.WebRequestRest
         public static bool TryGetFileNameFromUri(Uri uri, out string fileName)
         {
             fileName = null;
-            if (uri.IsFile) { return false; }
+            if (uri.Scheme == Uri.UriSchemeFile) { return false; }
             var baseUrl = UnityWebRequest.UnEscapeURL(uri.ToString());
             var rootUrl = baseUrl.Split('?')[0];
             var index = rootUrl.LastIndexOf('/') + 1;
@@ -895,7 +908,7 @@ namespace Utilities.WebRequestRest
             Uri cachePath;
             var restParams = parameters.Clone(disposeDownloadHandler: true);
 
-            if (uri.IsFile)
+            if (uri.Scheme == Uri.UriSchemeFile)
             {
                 isCached = true;
                 cachePath = uri;
@@ -908,7 +921,7 @@ namespace Utilities.WebRequestRest
                     TryGetFileNameFromUri(uri, out fileName);
                 }
 
-                isCached = TryGetDownloadCacheItem(new Uri(fileName!), out cachePath) && restParams.CacheDownloads;
+                isCached = TryGetDownloadCacheItem(fileName, out cachePath) && restParams.CacheDownloads;
             }
 
             if (isCached)
@@ -1028,7 +1041,7 @@ namespace Utilities.WebRequestRest
             Uri cachePath;
             var restParams = parameters.Clone();
 
-            if (uri.IsFile)
+            if (uri.Scheme == Uri.UriSchemeFile)
             {
                 isCached = true;
                 cachePath = uri;
@@ -1188,12 +1201,12 @@ namespace Utilities.WebRequestRest
             if (string.IsNullOrWhiteSpace(fileName) &&
                 !TryGetFileNameFromUri(uri, out fileName))
             {
-                fileName = uri.IsFile
+                fileName = uri.Scheme == Uri.UriSchemeFile
                     ? Path.GetFileName(uri.LocalPath)
                     : uri.GenerateGuidString();
             }
 
-            if (uri.IsFile)
+            if (uri.Scheme == Uri.UriSchemeFile)
             {
                 // override the httpMethod
                 httpMethod = UnityWebRequest.kHttpVerbGET;
@@ -1426,18 +1439,18 @@ namespace Utilities.WebRequestRest
                 TryGetFileNameFromUri(uri, out fileName);
             }
 
-            if (TryGetDownloadCacheItem(fileName, out string filePath) && restParams.CacheDownloads)
+            if (TryGetDownloadCacheItem(new Uri(fileName!, UriKind.Relative), out Uri filePath) && restParams.CacheDownloads)
             {
-                return filePath;
+                return filePath.LocalPath;
             }
 
             using var webRequest = UnityWebRequest.Get(uri);
-            using var fileDownloadHandler = new DownloadHandlerFile(filePath);
+            using var fileDownloadHandler = new DownloadHandlerFile(filePath.LocalPath);
             fileDownloadHandler.removeFileOnAbort = true;
             webRequest.downloadHandler = fileDownloadHandler;
             var response = await webRequest.SendAsync(restParams, cancellationToken);
             response.Validate(restParams.Debug);
-            return filePath;
+            return filePath.LocalPath;
         }
 
         /// <summary>

--- a/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
+++ b/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
@@ -936,9 +936,10 @@ namespace Utilities.WebRequestRest
             else
             {
                 if (restParams.CacheDownloads &&
-                    string.IsNullOrWhiteSpace(fileName))
+                    string.IsNullOrWhiteSpace(fileName) &&
+                    !TryGetFileNameFromUri(uri, out fileName))
                 {
-                    TryGetFileNameFromUri(uri, out fileName);
+                    fileName = uri.GenerateGuidString();
                 }
 
                 isCached = TryGetDownloadCacheItem(fileName, out cachePath) && restParams.CacheDownloads;
@@ -1069,9 +1070,10 @@ namespace Utilities.WebRequestRest
             else
             {
                 if (restParams.CacheDownloads &&
-                    string.IsNullOrWhiteSpace(fileName))
+                    string.IsNullOrWhiteSpace(fileName) &&
+                    !TryGetFileNameFromUri(uri, out fileName))
                 {
-                    TryGetFileNameFromUri(uri, out fileName);
+                    fileName = uri.GenerateGuidString();
                 }
 
                 isCached = TryGetDownloadCacheItem(fileName, out cachePath) && restParams.CacheDownloads;
@@ -1467,9 +1469,10 @@ namespace Utilities.WebRequestRest
             else
             {
                 if (restParams.CacheDownloads &&
-                    string.IsNullOrWhiteSpace(fileName))
+                    string.IsNullOrWhiteSpace(fileName) &&
+                    !TryGetFileNameFromUri(uri, out fileName))
                 {
-                    TryGetFileNameFromUri(uri, out fileName);
+                    fileName = uri.GenerateGuidString();
                 }
 
                 isCached = TryGetDownloadCacheItem(fileName, out cachePath) && restParams.CacheDownloads;

--- a/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
+++ b/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
@@ -2,6 +2,7 @@
 
 using Newtonsoft.Json;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -156,6 +157,7 @@ namespace Utilities.WebRequestRest
         {
             await Awaiters.UnityMainThread;
             using var webRequest = UnityWebRequest.Get(query);
+            webRequest.disposeDownloadHandlerOnDispose = false;
             using var downloadHandler = eventChunkSize.HasValue
                 ? new DownloadHandlerCallback(webRequest, eventChunkSize.Value)
                 : new DownloadHandlerCallback(webRequest);
@@ -366,6 +368,7 @@ namespace Utilities.WebRequestRest
             var data = new UTF8Encoding().GetBytes(jsonData);
             using var uploadHandler = new UploadHandlerRaw(data);
             webRequest.uploadHandler = uploadHandler;
+            webRequest.disposeDownloadHandlerOnDispose = false;
             using var downloadHandler = eventChunkSize.HasValue
                 ? new DownloadHandlerCallback(webRequest, eventChunkSize.Value)
                 : new DownloadHandlerCallback(webRequest);
@@ -749,6 +752,39 @@ namespace Utilities.WebRequestRest
             => cache.ValidateCacheDirectoryAsync();
 
         /// <summary>
+        /// Get the possible path to a cache item by fileName.
+        /// </summary>
+        /// <param name="fileName"></param>
+        /// <returns>
+        /// The full path to the cache item.
+        /// </returns>
+        /// <remarks>
+        /// This does not validate that the item exists in the cache.
+        /// </remarks>
+        public static string GetCacheItemPath(string fileName)
+        {
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                throw new ArgumentNullException(nameof(fileName));
+            }
+
+            return Path.Combine(DownloadCacheDirectory, fileName);
+        }
+
+        /// <summary>
+        /// Get the possible uri to a cache item by fileName.
+        /// </summary>
+        /// <param name="fileName"></param>
+        /// <returns>
+        /// The <see cref="Uri"/> to the cache item.
+        /// </returns>
+        /// <remarks>
+        /// This does not validate that the item exists in the cache.
+        /// </remarks>
+        public static Uri GetCacheItemUri(string fileName)
+            => new Uri(GetCacheItemPath(fileName));
+
+        /// <summary>
         /// Try to get a file out of the download cache by fileName reference.
         /// </summary>
         /// <param name="fileName">The filename of the item.</param>
@@ -758,7 +794,7 @@ namespace Utilities.WebRequestRest
         {
             var result = cache.TryGetDownloadCacheItem(fileName, out var fileUri);
             filePath = fileUri?.LocalPath;
-            return result;
+            return result && filePath != null;
         }
 
         /// <summary>
@@ -768,9 +804,7 @@ namespace Utilities.WebRequestRest
         /// <param name="fileUri">The <see cref="Uri"/> to the cached item.</param>
         /// <returns>True, if the item was in cache, otherwise false.</returns>
         public static bool TryGetDownloadCacheItem(string fileName, out Uri fileUri)
-        {
-            return cache.TryGetDownloadCacheItem(fileName, out fileUri);
-        }
+            => cache.TryGetDownloadCacheItem(fileName, out fileUri);
 
         /// <summary>
         /// Try to get a file out of the download cache by uri reference.
@@ -787,9 +821,7 @@ namespace Utilities.WebRequestRest
         /// <param name="uri">The uri key of the item.</param>
         /// <returns>True, if the cached item was successfully deleted.</returns>
         public static bool TryDeleteCacheItem(string uri)
-        {
-            return TryDeleteCacheItem(new Uri(uri));
-        }
+            => TryDeleteCacheItem(new Uri(uri));
 
         /// <summary>
         /// Try to delete the cached item at the uri.
@@ -811,35 +843,23 @@ namespace Utilities.WebRequestRest
         /// <param name="url">The url to parse to try to guess file name.</param>
         /// <param name="fileName">The filename if found.</param>
         /// <returns>True, if a valid filename is found from the url.</returns>
-        /// <remarks>
-        /// Url must start with "http" and the last segment must have a file extension, or it will return false.
-        /// </remarks>
-        [Obsolete("use TryGetFileNameFromUri")]
         public static bool TryGetFileNameFromUrl(string url, out string fileName)
-        {
-            fileName = null;
-            const string http = nameof(http);
-            if (!url.StartsWith(http)) { return false; }
-            var baseUrl = UnityWebRequest.UnEscapeURL(url);
-            var rootUrl = baseUrl.Split('?')[0];
-            var index = rootUrl.LastIndexOf('/') + 1;
-            fileName = rootUrl.Substring(index, rootUrl.Length - index);
-            return Path.HasExtension(fileName);
-        }
+            => TryGetFileNameFromUri(new Uri(url), out fileName);
 
         /// <summary>
         /// Try to guess the name based on the uri.
         /// </summary>
-        /// <param name="uri">The url to parse to try to guess file name.</param>
+        /// <param name="uri">The uri to parse to try to guess file name.</param>
         /// <param name="fileName">The filename if found.</param>
         /// <returns>True, if a valid filename is found from the uri.</returns>
-        /// <remarks>
-        /// Uri must be a remote resource and the last segment must have a file extension, or it will return false.
-        /// </remarks>
         public static bool TryGetFileNameFromUri(Uri uri, out string fileName)
         {
-            fileName = null;
-            if (uri.Scheme == Uri.UriSchemeFile) { return false; }
+            if (uri.Scheme == Uri.UriSchemeFile)
+            {
+                fileName = Path.GetFileName(uri.LocalPath);
+                return true;
+            }
+
             var baseUrl = UnityWebRequest.UnEscapeURL(uri.ToString());
             var rootUrl = baseUrl.Split('?')[0];
             var index = rootUrl.LastIndexOf('/') + 1;
@@ -1054,7 +1074,7 @@ namespace Utilities.WebRequestRest
                     TryGetFileNameFromUri(uri, out fileName);
                 }
 
-                isCached = TryGetDownloadCacheItem(new Uri(fileName!), out cachePath) && restParams.CacheDownloads;
+                isCached = TryGetDownloadCacheItem(fileName, out cachePath) && restParams.CacheDownloads;
             }
 
             if (isCached)
@@ -1406,16 +1426,19 @@ namespace Utilities.WebRequestRest
         /// <param name="parameters">Optional, <see cref="RestParameters"/>.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns>The path to the downloaded file.</returns>
-        public static Task<string> DownloadFileAsync(
+        public static async Task<string> DownloadFileAsync(
             string url,
             string fileName = null,
             RestParameters? parameters = null,
             CancellationToken cancellationToken = default)
-            => DownloadFileAsync(
+        {
+            var result = await DownloadFileAsync(
                 new Uri(url),
                 fileName,
                 parameters,
                 cancellationToken);
+            return result.LocalPath;
+        }
 
         /// <summary>
         /// Download a file from the provided <see cref="uri"/>.
@@ -1425,32 +1448,50 @@ namespace Utilities.WebRequestRest
         /// <param name="parameters">Optional, <see cref="RestParameters"/>.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns>The path to the downloaded file.</returns>
-        public static async Task<string> DownloadFileAsync(
+        public static async Task<Uri> DownloadFileAsync(
             Uri uri,
             string fileName = null,
             RestParameters? parameters = null,
             CancellationToken cancellationToken = default)
         {
             await Awaiters.UnityMainThread;
+            bool isCached;
+            Uri cachePath;
             var restParams = parameters.Clone();
 
-            if (string.IsNullOrWhiteSpace(fileName) && restParams.CacheDownloads)
+            if (uri.Scheme == Uri.UriSchemeFile)
             {
-                TryGetFileNameFromUri(uri, out fileName);
+                isCached = true;
+                cachePath = uri;
+            }
+            else
+            {
+                if (restParams.CacheDownloads &&
+                    string.IsNullOrWhiteSpace(fileName))
+                {
+                    TryGetFileNameFromUri(uri, out fileName);
+                }
+
+                isCached = TryGetDownloadCacheItem(fileName, out cachePath) && restParams.CacheDownloads;
             }
 
-            if (TryGetDownloadCacheItem(new Uri(fileName!, UriKind.Relative), out Uri filePath) && restParams.CacheDownloads)
+            if (isCached)
             {
-                return filePath.LocalPath;
+                uri = cachePath;
+            }
+
+            if (isCached)
+            {
+                return uri;
             }
 
             using var webRequest = UnityWebRequest.Get(uri);
-            using var fileDownloadHandler = new DownloadHandlerFile(filePath.LocalPath);
+            using var fileDownloadHandler = new DownloadHandlerFile(cachePath.LocalPath);
             fileDownloadHandler.removeFileOnAbort = true;
             webRequest.downloadHandler = fileDownloadHandler;
             var response = await webRequest.SendAsync(restParams, cancellationToken);
             response.Validate(restParams.Debug);
-            return filePath.LocalPath;
+            return cachePath;
         }
 
         /// <summary>
@@ -1488,12 +1529,11 @@ namespace Utilities.WebRequestRest
         {
             await Awaiters.UnityMainThread;
             byte[] bytes = null;
-            var filePath = await DownloadFileAsync(uri, fileName, parameters, cancellationToken);
-            var localPath = filePath.Replace("file://", string.Empty);
+            var fileUri = await DownloadFileAsync(uri, fileName, parameters, cancellationToken);
 
-            if (File.Exists(localPath))
+            if (File.Exists(fileUri.LocalPath))
             {
-                bytes = await File.ReadAllBytesAsync(localPath, cancellationToken).ConfigureAwait(true);
+                bytes = await File.ReadAllBytesAsync(fileUri.LocalPath, cancellationToken).ConfigureAwait(true);
             }
 
             return bytes;
@@ -1652,7 +1692,7 @@ namespace Utilities.WebRequestRest
             }
 
             var serverSentEventCharacterIndex = 0;
-            var serverSentEventQueue = new Queue<ServerSentEventPayload>();
+            var serverSentEventQueue = new ConcurrentQueue<ServerSentEventPayload?>();
             CancellationTokenSource serverSentEventCts = null;
 
             if (restParams.Progress != null || serverSentEventHandler != null)
@@ -1738,15 +1778,27 @@ namespace Utilities.WebRequestRest
                         try
                         {
                             await Awaiters.UnityMainThread;
-
-                            if (serverSentEventQueue.TryDequeue(out var payload))
+                            if (serverSentEventCts.Token.IsCancellationRequested) { break; }
+                            // ReSharper disable once ConditionIsAlwaysTrueOrFalse
+                            if (serverSentEventHandler != null &&
+                                serverSentEventQueue != null &&
+                                serverSentEventQueue.TryDequeue(out var payload))
                             {
-                                await serverSentEventHandler.Invoke(payload.Response, payload.Event);
+                                if (!payload.HasValue) { continue; }
+                                var task = serverSentEventHandler.Invoke(payload.Value.Response, payload.Value.Event);
+                                if (task == null) { continue; }
+                                await task.ConfigureAwait(false);
                             }
                         }
                         catch (Exception e)
                         {
-                            Debug.LogError(e);
+                            Debug.LogError($"[REST] {nameof(serverSentEventQueue)} EXCEPTION");
+                            var lines = e.ToString().Split('\n');
+
+                            foreach (var line in lines)
+                            {
+                                Debug.LogError(line);
+                            }
                         }
                     } while (!serverSentEventCts.Token.IsCancellationRequested);
                 }
@@ -1783,7 +1835,14 @@ namespace Utilities.WebRequestRest
 
                 if (serverSentEventHandler != null)
                 {
-                    EnqueueServerSentEventCallbacks();
+                    try
+                    {
+                        EnqueueServerSentEventCallbacks();
+                    }
+                    catch (Exception e)
+                    {
+                        Debug.LogException(e);
+                    }
                 }
 
                 if (serverSentEventCts != null)
@@ -2013,6 +2072,7 @@ namespace Utilities.WebRequestRest
             }
 
             public Response Response { get; }
+
             public ServerSentEvent Event { get; }
         }
 

--- a/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
+++ b/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
@@ -1407,7 +1407,7 @@ namespace Utilities.WebRequestRest
 
             using (webRequest)
             {
-                parameters = parameters.Clone(disposeDownloadHandler: false, timeout: options?.Timeout);
+                var restParams = parameters.Clone(disposeDownloadHandler: false, timeout: options?.Timeout);
                 var response = await webRequest.SendAsync(restParams, cancellationToken);
                 response.Validate(restParams.Debug);
 
@@ -1776,15 +1776,19 @@ namespace Utilities.WebRequestRest
                 async void ServerSentEventQueue()
                 {
                     serverSentEventCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                    await Awaiters.UnityMainThread;
+
                     do
                     {
                         try
                         {
-                            await Awaiters.UnityMainThread;
-
                             if (serverSentEventQueue.TryDequeue(out var payload))
                             {
-                                await serverSentEventHandler.Invoke(payload.Response, payload.Event).ConfigureAwait(false);
+                                await serverSentEventHandler.Invoke(payload.Response, payload.Event).ConfigureAwait(true);
+                            }
+                            else
+                            {
+                                await Task.Yield();
                             }
                         }
                         catch (Exception e)

--- a/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
+++ b/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
@@ -157,7 +157,7 @@ namespace Utilities.WebRequestRest
         {
             await Awaiters.UnityMainThread;
             using var webRequest = UnityWebRequest.Get(query);
-            parameters = parameters?.Clone(disposeDownloadHandler: false);
+            parameters = parameters.Clone(disposeDownloadHandler: false);
             using var downloadHandler = eventChunkSize.HasValue
                 ? new DownloadHandlerCallback(webRequest, eventChunkSize.Value)
                 : new DownloadHandlerCallback(webRequest);
@@ -279,6 +279,7 @@ namespace Utilities.WebRequestRest
             using var downloadHandler = new DownloadHandlerBuffer();
             webRequest.downloadHandler = downloadHandler;
             webRequest.SetRequestHeader(content_type, application_json);
+            parameters = parameters.Clone(disposeDownloadHandler: false, disposeUploadHandler: false);
             return await webRequest.SendAsync(parameters, cancellationToken);
         }
 
@@ -323,6 +324,7 @@ namespace Utilities.WebRequestRest
             using var downloadHandler = new DownloadHandlerBuffer();
             webRequest.downloadHandler = downloadHandler;
             webRequest.SetRequestHeader(content_type, application_json);
+            parameters = parameters.Clone(disposeDownloadHandler: false, disposeUploadHandler: false);
             return await webRequest.SendAsync(parameters, serverSentEventHandler, cancellationToken);
         }
 
@@ -368,7 +370,6 @@ namespace Utilities.WebRequestRest
             var data = new UTF8Encoding().GetBytes(jsonData);
             using var uploadHandler = new UploadHandlerRaw(data);
             webRequest.uploadHandler = uploadHandler;
-            parameters = parameters?.Clone(disposeDownloadHandler: false);
             using var downloadHandler = eventChunkSize.HasValue
                 ? new DownloadHandlerCallback(webRequest, eventChunkSize.Value)
                 : new DownloadHandlerCallback(webRequest);
@@ -378,6 +379,7 @@ namespace Utilities.WebRequestRest
 
             try
             {
+                parameters = parameters.Clone(disposeDownloadHandler: false, disposeUploadHandler: false);
                 return await webRequest.SendAsync(parameters, serverSentEventHandler: null, cancellationToken);
             }
             finally
@@ -423,6 +425,7 @@ namespace Utilities.WebRequestRest
             using var downloadHandler = new DownloadHandlerBuffer();
             webRequest.downloadHandler = downloadHandler;
             webRequest.SetRequestHeader(content_type, application_octet_stream);
+            parameters = parameters.Clone(disposeDownloadHandler: false, disposeUploadHandler: false);
             return await webRequest.SendAsync(parameters, cancellationToken);
         }
 
@@ -464,6 +467,7 @@ namespace Utilities.WebRequestRest
             webRequest.uploadHandler = uploadHandler;
             using var downloadHandler = new DownloadHandlerBuffer();
             webRequest.downloadHandler = downloadHandler;
+            parameters = parameters.Clone(disposeDownloadHandler: false, disposeUploadHandler: false);
             return await webRequest.SendAsync(parameters, cancellationToken);
         }
 
@@ -650,6 +654,7 @@ namespace Utilities.WebRequestRest
             using var webRequest = UnityWebRequest.Delete(query);
             using var downloadHandler = new DownloadHandlerBuffer();
             webRequest.downloadHandler = downloadHandler;
+            parameters = parameters.Clone(disposeDownloadHandler: false);
             return await webRequest.SendAsync(parameters, cancellationToken);
         }
 
@@ -1402,7 +1407,7 @@ namespace Utilities.WebRequestRest
 
             using (webRequest)
             {
-                var restParams = parameters.Clone(disposeDownloadHandler: false, timeout: options?.Timeout);
+                parameters = parameters.Clone(disposeDownloadHandler: false, timeout: options?.Timeout);
                 var response = await webRequest.SendAsync(restParams, cancellationToken);
                 response.Validate(restParams.Debug);
 
@@ -1459,7 +1464,6 @@ namespace Utilities.WebRequestRest
             await Awaiters.UnityMainThread;
             bool isCached;
             Uri cachePath;
-            var restParams = parameters.Clone();
 
             if (uri.Scheme == Uri.UriSchemeFile)
             {
@@ -1468,32 +1472,27 @@ namespace Utilities.WebRequestRest
             }
             else
             {
-                if (restParams.CacheDownloads &&
-                    string.IsNullOrWhiteSpace(fileName) &&
+                if (string.IsNullOrWhiteSpace(fileName) &&
                     !TryGetFileNameFromUri(uri, out fileName))
                 {
                     fileName = uri.GenerateGuidString();
                 }
 
-                isCached = TryGetDownloadCacheItem(fileName, out cachePath) && restParams.CacheDownloads;
+                isCached = TryGetDownloadCacheItem(fileName, out cachePath);
             }
 
             if (isCached)
             {
-                uri = cachePath;
-            }
-
-            if (isCached)
-            {
-                return uri;
+                return cachePath;
             }
 
             using var webRequest = UnityWebRequest.Get(uri);
             using var fileDownloadHandler = new DownloadHandlerFile(cachePath.LocalPath);
             fileDownloadHandler.removeFileOnAbort = true;
             webRequest.downloadHandler = fileDownloadHandler;
-            var response = await webRequest.SendAsync(restParams, cancellationToken);
-            response.Validate(restParams.Debug);
+            parameters = parameters.Clone(disposeDownloadHandler: false);
+            var response = await webRequest.SendAsync(parameters, cancellationToken);
+            response.Validate(parameters.Value.Debug);
             return cachePath;
         }
 
@@ -1576,8 +1575,9 @@ namespace Utilities.WebRequestRest
             using var webRequest = UnityWebRequest.Get(uri);
             using var downloadHandlerBuffer = new DownloadHandlerBuffer();
             webRequest.downloadHandler = downloadHandlerBuffer;
+            parameters = parameters.Clone(disposeDownloadHandler: false);
             var response = await webRequest.SendAsync(parameters, cancellationToken);
-            response.Validate(parameters?.Debug ?? false);
+            response.Validate(parameters.Value.Debug);
             return response.Data;
         }
 

--- a/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
+++ b/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
@@ -157,7 +157,7 @@ namespace Utilities.WebRequestRest
         {
             await Awaiters.UnityMainThread;
             using var webRequest = UnityWebRequest.Get(query);
-            webRequest.disposeDownloadHandlerOnDispose = false;
+            parameters = parameters?.Clone(disposeDownloadHandler: false);
             using var downloadHandler = eventChunkSize.HasValue
                 ? new DownloadHandlerCallback(webRequest, eventChunkSize.Value)
                 : new DownloadHandlerCallback(webRequest);
@@ -368,7 +368,7 @@ namespace Utilities.WebRequestRest
             var data = new UTF8Encoding().GetBytes(jsonData);
             using var uploadHandler = new UploadHandlerRaw(data);
             webRequest.uploadHandler = uploadHandler;
-            webRequest.disposeDownloadHandlerOnDispose = false;
+            parameters = parameters?.Clone(disposeDownloadHandler: false);
             using var downloadHandler = eventChunkSize.HasValue
                 ? new DownloadHandlerCallback(webRequest, eventChunkSize.Value)
                 : new DownloadHandlerCallback(webRequest);

--- a/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
+++ b/Utilities.Rest/Packages/com.utilities.rest/Runtime/Rest.cs
@@ -1695,7 +1695,7 @@ namespace Utilities.WebRequestRest
             }
 
             var serverSentEventCharacterIndex = 0;
-            var serverSentEventQueue = new ConcurrentQueue<ServerSentEventPayload?>();
+            var serverSentEventQueue = new ConcurrentQueue<ServerSentEventPayload>();
             CancellationTokenSource serverSentEventCts = null;
 
             if (restParams.Progress != null || serverSentEventHandler != null)
@@ -1781,27 +1781,15 @@ namespace Utilities.WebRequestRest
                         try
                         {
                             await Awaiters.UnityMainThread;
-                            if (serverSentEventCts.Token.IsCancellationRequested) { break; }
-                            // ReSharper disable once ConditionIsAlwaysTrueOrFalse
-                            if (serverSentEventHandler != null &&
-                                serverSentEventQueue != null &&
-                                serverSentEventQueue.TryDequeue(out var payload))
+
+                            if (serverSentEventQueue.TryDequeue(out var payload))
                             {
-                                if (!payload.HasValue) { continue; }
-                                var task = serverSentEventHandler.Invoke(payload.Value.Response, payload.Value.Event);
-                                if (task == null) { continue; }
-                                await task.ConfigureAwait(false);
+                                await serverSentEventHandler.Invoke(payload.Response, payload.Event).ConfigureAwait(false);
                             }
                         }
                         catch (Exception e)
                         {
-                            Debug.LogError($"[REST] {nameof(serverSentEventQueue)} EXCEPTION");
-                            var lines = e.ToString().Split('\n');
-
-                            foreach (var line in lines)
-                            {
-                                Debug.LogError(line);
-                            }
+                            Debug.LogException(e);
                         }
                     } while (!serverSentEventCts.Token.IsCancellationRequested);
                 }
@@ -1861,8 +1849,6 @@ namespace Utilities.WebRequestRest
                     finally
                     {
                         serverSentEventCts?.Cancel();
-                        serverSentEventCts?.Dispose();
-                        serverSentEventCts = null;
                     }
                 }
             }

--- a/Utilities.Rest/Packages/com.utilities.rest/package.json
+++ b/Utilities.Rest/Packages/com.utilities.rest/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.Rest",
   "description": "This package contains useful RESTful utilities for the Unity Game Engine.",
   "keywords": [],
-  "version": "5.1.0",
+  "version": "5.1.1",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.rest#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.rest/releases",
@@ -16,7 +16,7 @@
   "url": "https://github.com/StephenHodgson",
   "dependencies": {
     "com.utilities.async": "3.0.2",
-    "com.utilities.extensions": "1.3.6",
+    "com.utilities.extensions": "1.3.8",
     "com.unity.modules.unitywebrequest": "1.0.0",
     "com.unity.modules.unitywebrequestassetbundle": "1.0.0",
     "com.unity.modules.unitywebrequestaudio": "1.0.0",


### PR DESCRIPTION
- Fix uri implementation for determining local cached item
  - Replaced usage of `uri.IsFile` with `uri.Scheme == Uri.UriSchemeFile` throughout the codebase for more accurate URI type checks
  - Introduced `GetCacheItemPath` and `GetCacheItemUri` static methods to generate cache paths and URIs from file names, improving code clarity and reuse
  - Updated file download and cache-checking logic to use the new file name-based methods, improving correctness and reducing reliance on URI string parsing
- Added new overloads for `TryGetDownloadCacheItem` to support cache lookup by `fileName` in both the `IDownloadCache` interface and its implementations, and updated usages throughout the codebase for consistency
-  Replaced `Queue<ServerSentEventPayload>` with thread-safe `ConcurrentQueue<ServerSentEventPayload>` for handling server-sent events, and improved error handling and logging for event processing.
- Bump com.utilities.extensions 1.3.8